### PR TITLE
FEAT: 로그아웃 기능 일부 구현 & 로그인 시 RefreshKey DB 저장

### DIFF
--- a/src/main/java/com/bbacks/bst/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bbacks/bst/domain/auth/controller/AuthController.java
@@ -7,9 +7,11 @@ import com.bbacks.bst.domain.auth.dto.TokenResponse;
 import com.bbacks.bst.domain.auth.service.AuthService;
 import com.bbacks.bst.global.response.ApiResponseDto;
 import com.bbacks.bst.global.response.SuccessStatus;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -41,6 +43,18 @@ public class AuthController {
         AccessTokenResponse accessTokenResponse = AccessTokenResponse.builder()
                 .accessToken(newAccessToken)
                 .build();
-        return ApiResponseDto.success(SuccessStatus.POST_SUCCESS, accessTokenResponse);
+        return ApiResponseDto.success(SuccessStatus.REFRESH_SUCCESS, accessTokenResponse);
+    }
+
+    @PostMapping("/logout")
+    public ApiResponseDto<?> logout(Authentication authentication){
+        Long userId = getUserId(authentication);
+        authService.logout(userId);
+        log.info("로그아웃됨");
+        return ApiResponseDto.success(SuccessStatus.LOGOUT_SUCCESS);
+    }
+
+    private Long getUserId(Authentication authentication){
+        return Long.parseLong(authentication.getName());
     }
 }

--- a/src/main/java/com/bbacks/bst/global/config/SecurityConfig.java
+++ b/src/main/java/com/bbacks/bst/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -26,12 +27,13 @@ public class SecurityConfig {
 
     private final AuthService authService;
     private final JwtService jwtService;
-    private final UserRepository userRepository;
+    //private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomAuthorizationRequestRepository customAuthorizationRequestRepository;
+    //private final RedisTemplate redisTemplate;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/bbacks/bst/global/exception/UserNotFoundInRedisException.java
+++ b/src/main/java/com/bbacks/bst/global/exception/UserNotFoundInRedisException.java
@@ -1,0 +1,10 @@
+package com.bbacks.bst.global.exception;
+
+import com.bbacks.bst.global.response.ErrorStatus;
+
+public class UserNotFoundInRedisException extends RuntimeException {
+
+    public UserNotFoundInRedisException() {
+        super(ErrorStatus.NEED_LOGIN_EXCEPTION.getMessage());
+    }
+}

--- a/src/main/java/com/bbacks/bst/global/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/bbacks/bst/global/jwt/filter/JwtFilter.java
@@ -1,6 +1,10 @@
 package com.bbacks.bst.global.jwt.filter;
 
 import com.bbacks.bst.domain.auth.service.AuthService;
+import com.bbacks.bst.domain.user.domain.User;
+import com.bbacks.bst.domain.user.repository.UserRepository;
+import com.bbacks.bst.global.exception.UserIdNotFoundException;
+import com.bbacks.bst.global.exception.UserNotFoundInRedisException;
 import com.bbacks.bst.global.jwt.service.JwtService;
 import com.bbacks.bst.global.response.ApiResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,9 +13,11 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpHeaders;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -30,6 +36,11 @@ public class JwtFilter extends OncePerRequestFilter {
     private final AuthService authService;
     private final JwtService jwtService;
     private ObjectMapper objectMapper = new ObjectMapper();
+/*
+    private final UserRepository userRepository;
+    private final RedisTemplate redisTemplate;*/
+
+
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -39,6 +50,14 @@ public class JwtFilter extends OncePerRequestFilter {
                 String socialId = jwtService.getSocialId(token);
 
                 Long userId = authService.checkSocialIdAndGetUserId(socialId);
+
+                /*//로그인된 유저가 맞는지 검증
+                User user = userRepository.findByUserSocialId(socialId)
+                        .orElseThrow(UserIdNotFoundException::new);
+                String redisKey = user.getUserToken();
+                if(!redisTemplate.hasKey(redisKey) || redisTemplate.opsForValue().get(redisKey) == null) {
+                    throw new UserNotFoundInRedisException();
+                }   */
 
                 // 권한 부여
                 UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userId, null, List

--- a/src/main/java/com/bbacks/bst/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/bbacks/bst/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -45,7 +45,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         log.info("RefreshToken: " + refreshToken);
         log.info("Token 생성 완료!");
 
-        String refreshKey = authService.saveRefreshTokenInRedis(refreshToken);
+        String refreshKey = authService.saveRefreshTokenInRedis(refreshToken); //Redis에 저장
+        authService.saveRefreshKey(refreshKey, userSocialId); //DB에 저장
         log.info("RefreshKey: " + refreshKey);
         log.info("Token 전송 및 저장 완료!");
 

--- a/src/main/java/com/bbacks/bst/global/response/SuccessStatus.java
+++ b/src/main/java/com/bbacks/bst/global/response/SuccessStatus.java
@@ -14,6 +14,8 @@ public enum SuccessStatus {
     BOOKMARK_SAVE_SUCCESS(HttpStatus.OK, "북마크되었습니다."),
     BOOKMARK_DELETE_SUCCESS(HttpStatus.OK, "북마크해제되었습니다."),
     LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공했습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃했습니다."),
+    REFRESH_SUCCESS(HttpStatus.OK, "토큰 재발급 성공했습니다."),
     DEBATE_POST_SUCCESS(HttpStatus.OK, "글 작성에 성공했습니다."),
     DELETE_POST_SUCCESS(HttpStatus.OK, "글이 삭제되었습니다."),
     CREATE_DEBATE_SUCCESS(HttpStatus.OK, "토론이 개설되었습니다."),


### PR DESCRIPTION
💫**구현한 기능**💫
- [x] 로그아웃 API 구현
- [x] 로그인 시 RefreshKey mySql에 저장하도록 함

💬**참고**💬
- 현재 로그아웃 상태인지 검증하는 로직은 오류로 적용 못함.
- 로그아웃 로직: 호출 시 Redis 내 value값을 지움.